### PR TITLE
fix(nvenc/amf): repair NVENC + AMD encoders for H.264 + H.265 (preset, profile, RTMP, MPEG-TS/SRT) (issue #5)

### DIFF
--- a/src/amd-encoder.c
+++ b/src/amd-encoder.c
@@ -208,6 +208,29 @@ void amd_encoder_destroy(amd_encoder_t *enc) {
   bfree(enc);
 }
 
+/*
+ * Resolve the codec-appropriate profile string for FFmpeg's *_amf encoders.
+ * The unified-encoder UI exposes H.264 profile names (baseline/main/high) for
+ * all codecs, but hevc_amf accepts only "main" and av1_amf only "main".
+ * Passing "high" to hevc_amf returns EINVAL from avcodec_open2, so H.265 never
+ * opens. Coerce unrecognised values to a sensible per-codec default.
+ *
+ * codec_type: 0 = H.264, 1 = H.265, 2 = AV1.
+ * Returns NULL to mean "do not set the profile option".
+ */
+static const char *amd_resolve_profile(int codec_type, const char *in) {
+  if (codec_type == 0) { /* h264_amf: baseline/main/high/constrained_* */
+    if (!in || !*in)
+      return "high";
+    return in;
+  }
+  if (codec_type == 1) /* hevc_amf: main only */
+    return "main";
+  if (codec_type == 2) /* av1_amf: main */
+    return "main";
+  return NULL;
+}
+
 /* 创建编码器 - Internal (public for unified encoder) */
 void *amd_encoder_create_internal(obs_data_t *settings,
                                   obs_encoder_t *encoder) {
@@ -299,9 +322,14 @@ void *amd_encoder_create_internal(obs_data_t *settings,
     encoder_log(LOG_INFO, enc, "Using quality preset: %s", enc->preset);
   }
 
-  /* Profile */
-  if (enc->profile && strlen(enc->profile) > 0) {
-    av_dict_set(&opts, "profile", enc->profile, 0);
+  /* Profile (coerce to codec-valid value - the UI exposes H.264 names for all
+   * codecs, but hevc_amf/av1_amf reject "high" with EINVAL). */
+  const char *amf_profile = amd_resolve_profile(enc->codec_type, enc->profile);
+  if (amf_profile) {
+    av_dict_set(&opts, "profile", amf_profile, 0);
+    encoder_log(LOG_INFO, enc, "Using AMF profile: %s (requested: %s)",
+                amf_profile,
+                (enc->profile && *enc->profile) ? enc->profile : "(default)");
   }
 
   /* Rate control - CBR */

--- a/src/nvenc-encoder.c
+++ b/src/nvenc-encoder.c
@@ -92,6 +92,103 @@ static bool nvenc_build_sei_nal_unit(uint8_t *payload, size_t payload_size,
 #endif
 
 /*
+ * Convert FFmpeg's H.264 extradata to a raw Annex-B byte stream so it can be
+ * prepended inline at each keyframe. FFmpeg's h264_nvenc emits extradata in
+ * Annex-B form (with start codes) when AV_CODEC_FLAG_GLOBAL_HEADER is set, but
+ * for safety we also handle the AVCDecoderConfigurationRecord (AVCC) form.
+ * Returns a bmalloc'd buffer, or NULL on failure. *out_size is set to 0 on
+ * failure or when the input format is unrecognised.
+ */
+static uint8_t *nvenc_h264_extradata_to_annexb(const uint8_t *extradata,
+                                               size_t extradata_size,
+                                               size_t *out_size) {
+  *out_size = 0;
+  if (!extradata || extradata_size < 4)
+    return NULL;
+
+  /* Annex-B already? Either 0x00 0x00 0x00 0x01 or 0x00 0x00 0x01. */
+  bool is_annexb =
+      (extradata[0] == 0 && extradata[1] == 0 &&
+       ((extradata[2] == 0 && extradata[3] == 1) || extradata[2] == 1));
+  if (is_annexb) {
+    uint8_t *out = bmalloc(extradata_size);
+    memcpy(out, extradata, extradata_size);
+    *out_size = extradata_size;
+    return out;
+  }
+
+  /* AVCDecoderConfigurationRecord: configurationVersion must be 1. */
+  if (extradata[0] != 0x01 || extradata_size < 7)
+    return NULL;
+
+  /* Layout:
+   *   [0]      configurationVersion (=1)
+   *   [1..3]   profile/compat/level
+   *   [4]      6 reserved bits | 2 lengthSizeMinusOne bits
+   *   [5]      3 reserved bits | 5 numOfSequenceParameterSets bits
+   *   [6..]    array of {2-byte length BE, SPS NAL bytes}
+   *            then 1 byte numOfPictureParameterSets
+   *            then array of {2-byte length BE, PPS NAL bytes}
+   */
+  size_t pos = 5;
+  int num_sps = extradata[pos++] & 0x1F;
+  size_t total = 0;
+
+  /* Pass 1: validate ranges and tally output size. */
+  size_t scan = pos;
+  for (int i = 0; i < num_sps; i++) {
+    if (scan + 2 > extradata_size)
+      return NULL;
+    uint16_t len = ((uint16_t)extradata[scan] << 8) | extradata[scan + 1];
+    scan += 2;
+    if (scan + len > extradata_size)
+      return NULL;
+    total += 4 + len; /* 4-byte start code + NAL */
+    scan += len;
+  }
+  if (scan + 1 > extradata_size)
+    return NULL;
+  int num_pps = extradata[scan++];
+  for (int i = 0; i < num_pps; i++) {
+    if (scan + 2 > extradata_size)
+      return NULL;
+    uint16_t len = ((uint16_t)extradata[scan] << 8) | extradata[scan + 1];
+    scan += 2;
+    if (scan + len > extradata_size)
+      return NULL;
+    total += 4 + len;
+    scan += len;
+  }
+  if (total == 0)
+    return NULL;
+
+  /* Pass 2: emit Annex-B. */
+  uint8_t *out = bmalloc(total);
+  uint8_t *wp = out;
+  scan = pos;
+  for (int i = 0; i < num_sps; i++) {
+    uint16_t len = ((uint16_t)extradata[scan] << 8) | extradata[scan + 1];
+    scan += 2;
+    *wp++ = 0; *wp++ = 0; *wp++ = 0; *wp++ = 1;
+    memcpy(wp, extradata + scan, len);
+    wp += len;
+    scan += len;
+  }
+  scan++; /* skip num_pps */
+  for (int i = 0; i < num_pps; i++) {
+    uint16_t len = ((uint16_t)extradata[scan] << 8) | extradata[scan + 1];
+    scan += 2;
+    *wp++ = 0; *wp++ = 0; *wp++ = 0; *wp++ = 1;
+    memcpy(wp, extradata + scan, len);
+    wp += len;
+    scan += len;
+  }
+
+  *out_size = total;
+  return out;
+}
+
+/*
  * Translate the unified-encoder UI preset ("fast"/"balanced"/"quality") to a
  * modern NVENC SDK 10+ P1-P7 preset accepted by FFmpeg's h264_nvenc/hevc_nvenc/
  * av1_nvenc. The legacy presets (default/slow/medium/fast/hp/hq/bd/ll/llhq/llhp/
@@ -226,6 +323,8 @@ void nvenc_encoder_destroy(nvenc_encoder_t *enc) {
 
   if (enc->extra_data)
     bfree(enc->extra_data);
+  if (enc->inline_params)
+    bfree(enc->inline_params);
   if (enc->profile)
     bfree(enc->profile);
   if (enc->preset)
@@ -317,7 +416,17 @@ void *nvenc_encoder_create_internal(obs_data_t *settings,
   enc->codec_context->bit_rate = enc->bitrate * 1000;
   enc->codec_context->gop_size = enc->keyint;
   enc->codec_context->max_b_frames = enc->bframes;
-  /* enc->codec_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER; */
+
+  /* For H.264 only: enable GLOBAL_HEADER so FFmpeg populates extradata at
+   * avcodec_open2() with an SPS/PPS sequence header. Without this, NVENC's
+   * extradata stays empty and OBS's RTMP/FLV muxer has no AVCDecoder-
+   * ConfigurationRecord to send, which causes ingest servers (e.g. Streamshark)
+   * to drop the stream within ~100ms with zero frames sent. We restore the
+   * inline SPS/PPS at each keyframe ourselves below, preserving MPEG-TS/SRT
+   * behaviour. H.265 keeps its v1.2.2 SLS-compat behaviour (no GLOBAL_HEADER). */
+  if (enc->codec_type == 0) {
+    enc->codec_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+  }
 
   /* NVENC 特定选项 */
   AVDictionary *opts = NULL;
@@ -364,6 +473,27 @@ void *nvenc_encoder_create_internal(obs_data_t *settings,
            enc->extra_data_size);
     encoder_log(LOG_INFO, enc, "Extra data size: %zu bytes",
                 enc->extra_data_size);
+
+    /* For H.264 with GLOBAL_HEADER on, build a reusable Annex-B SPS/PPS
+     * payload so we can keep parameter sets inline at every keyframe (needed
+     * for SRT/MPEG-TS receivers that join mid-stream). */
+    if (enc->codec_type == 0) {
+      enc->inline_params = nvenc_h264_extradata_to_annexb(
+          enc->extra_data, enc->extra_data_size, &enc->inline_params_size);
+      if (enc->inline_params && enc->inline_params_size > 0) {
+        encoder_log(LOG_INFO, enc,
+                    "Inline SPS/PPS payload built: %zu bytes (Annex-B)",
+                    enc->inline_params_size);
+      } else {
+        encoder_log(LOG_WARNING, enc,
+                    "Could not build inline SPS/PPS from extradata; SRT "
+                    "consumers may need to wait for next out-of-band header");
+      }
+    }
+  } else if (enc->codec_type == 0) {
+    encoder_log(LOG_WARNING, enc,
+                "H.264 extradata is empty after open — RTMP/FLV will likely "
+                "fail (no AVC sequence header)");
   }
 
   encoder_log(LOG_INFO, enc,
@@ -474,25 +604,39 @@ bool nvenc_encoder_encode_internal(void *data, struct encoder_frame *frame,
         enc->packet->data, enc->packet->size, enc->codec_type);
 
     if (param_sets_end > 0 && param_sets_end < enc->packet->size) {
-      /* 正确顺序: 参数集 → SEI → IDR slice */
-      /* 1. 复制参数集 */
+      /* FFmpeg emitted SPS/PPS inline (e.g. H.265 path, or H.264 without
+       * GLOBAL_HEADER). Order: existing parameter sets → SEI → IDR slice. */
       memcpy(enc->packet_buffer, enc->packet->data, param_sets_end);
       size_t offset = param_sets_end;
-
-      /* 2. 插入SEI */
       memcpy(enc->packet_buffer + offset, sei_nal, sei_nal_size);
       offset += sei_nal_size;
-
-      /* 3. 复制剩余数据 */
       size_t remaining = enc->packet->size - param_sets_end;
       memcpy(enc->packet_buffer + offset, enc->packet->data + param_sets_end,
              remaining);
-
       encoder_log(LOG_DEBUG, enc,
                   "SEI inserted after parameter sets (offset: %zu)",
                   param_sets_end);
+    } else if (enc->inline_params && enc->inline_params_size > 0) {
+      /* GLOBAL_HEADER path (H.264): FFmpeg dropped SPS/PPS from the packet;
+       * re-inject them inline so MPEG-TS/SRT receivers can still decode.
+       * Order: SPS/PPS (Annex-B from extradata) → SEI → IDR slice. */
+      total_size =
+          enc->inline_params_size + sei_nal_size + enc->packet->size;
+      if (enc->packet_buffer_size < total_size) {
+        bfree(enc->packet_buffer);
+        enc->packet_buffer = bmalloc(total_size);
+        enc->packet_buffer_size = total_size;
+      }
+      memcpy(enc->packet_buffer, enc->inline_params, enc->inline_params_size);
+      size_t offset = enc->inline_params_size;
+      memcpy(enc->packet_buffer + offset, sei_nal, sei_nal_size);
+      offset += sei_nal_size;
+      memcpy(enc->packet_buffer + offset, enc->packet->data, enc->packet->size);
+      encoder_log(LOG_DEBUG, enc,
+                  "Inline SPS/PPS+SEI prepended to keyframe (%zu + %zu bytes)",
+                  enc->inline_params_size, sei_nal_size);
     } else {
-      /* Fallback到旧行为 */
+      /* Last-resort fallback: just put SEI before the IDR slice. */
       encoder_log(LOG_WARNING, enc,
                   "Could not find parameter sets end, inserting SEI at "
                   "beginning (may cause decoding issues)");

--- a/src/nvenc-encoder.c
+++ b/src/nvenc-encoder.c
@@ -91,6 +91,28 @@ static bool nvenc_build_sei_nal_unit(uint8_t *payload, size_t payload_size,
 }
 #endif
 
+/*
+ * Translate the unified-encoder UI preset ("fast"/"balanced"/"quality") to a
+ * modern NVENC SDK 10+ P1-P7 preset accepted by FFmpeg's h264_nvenc/hevc_nvenc/
+ * av1_nvenc. The legacy presets (default/slow/medium/fast/hp/hq/bd/ll/llhq/llhp/
+ * lossless/losslesshp) were deprecated by NVIDIA starting with the R550 driver,
+ * so passing them through to FFmpeg fails with EINVAL on modern systems.
+ * Already-valid P1-P7 strings pass through unchanged.
+ */
+static const char *nvenc_translate_preset(const char *in) {
+  if (!in || !*in)
+    return "p4";
+  if (strcmp(in, "fast") == 0)
+    return "p2";
+  if (strcmp(in, "balanced") == 0)
+    return "p4";
+  if (strcmp(in, "quality") == 0)
+    return "p7";
+  if (in[0] == 'p' && in[1] >= '1' && in[1] <= '7' && in[2] == '\0')
+    return in;
+  return "p4";
+}
+
 /* H.264/H.265 NAL类型定义 */
 #define H264_NAL_SPS 7
 #define H264_NAL_PPS 8
@@ -300,11 +322,12 @@ void *nvenc_encoder_create_internal(obs_data_t *settings,
   /* NVENC 特定选项 */
   AVDictionary *opts = NULL;
 
-  /* Preset */
-  if (enc->preset && strlen(enc->preset) > 0) {
-    av_dict_set(&opts, "preset", enc->preset, 0);
-    encoder_log(LOG_INFO, enc, "Using preset: %s", enc->preset);
-  }
+  /* Preset (translate to NVENC SDK 10+ P1-P7 — legacy presets are deprecated
+   * by the R550 driver and cause EINVAL on modern systems) */
+  const char *nvenc_preset = nvenc_translate_preset(enc->preset);
+  av_dict_set(&opts, "preset", nvenc_preset, 0);
+  encoder_log(LOG_INFO, enc, "Using NVENC preset: %s (requested: %s)",
+              nvenc_preset, (enc->preset && *enc->preset) ? enc->preset : "(default)");
 
   /* Profile */
   if (enc->profile && strlen(enc->profile) > 0) {

--- a/src/nvenc-encoder.c
+++ b/src/nvenc-encoder.c
@@ -92,16 +92,18 @@ static bool nvenc_build_sei_nal_unit(uint8_t *payload, size_t payload_size,
 #endif
 
 /*
- * Convert FFmpeg's H.264 extradata to a raw Annex-B byte stream so it can be
- * prepended inline at each keyframe. FFmpeg's h264_nvenc emits extradata in
- * Annex-B form (with start codes) when AV_CODEC_FLAG_GLOBAL_HEADER is set, but
- * for safety we also handle the AVCDecoderConfigurationRecord (AVCC) form.
+ * Convert FFmpeg encoder extradata to a raw Annex-B byte stream so it can be
+ * prepended inline at each keyframe. FFmpeg's h264_nvenc / hevc_nvenc both
+ * emit extradata in Annex-B form (start codes) under AV_CODEC_FLAG_GLOBAL_HEADER,
+ * which is the path this plugin uses. As a defensive fallback the H.264
+ * AVCDecoderConfigurationRecord (AVCC) layout is also parsed; HEVC's HVCC is
+ * not (it would return NULL → caller warning, harmless for the Annex-B case).
  * Returns a bmalloc'd buffer, or NULL on failure. *out_size is set to 0 on
  * failure or when the input format is unrecognised.
  */
-static uint8_t *nvenc_h264_extradata_to_annexb(const uint8_t *extradata,
-                                               size_t extradata_size,
-                                               size_t *out_size) {
+static uint8_t *nvenc_extradata_to_annexb(const uint8_t *extradata,
+                                          size_t extradata_size,
+                                          size_t *out_size) {
   *out_size = 0;
   if (!extradata || extradata_size < 4)
     return NULL;
@@ -208,6 +210,33 @@ static const char *nvenc_translate_preset(const char *in) {
   if (in[0] == 'p' && in[1] >= '1' && in[1] <= '7' && in[2] == '\0')
     return in;
   return "p4";
+}
+
+/*
+ * Resolve the codec-appropriate profile string for FFmpeg's *_nvenc encoders.
+ * The unified-encoder UI exposes H.264 profile names (baseline/main/high) for
+ * all codecs, but hevc_nvenc accepts only main/main10/rext and av1_nvenc only
+ * main. Passing "high" to hevc_nvenc returns EINVAL from avcodec_open2 — so
+ * we coerce unrecognised values to a sensible per-codec default.
+ *
+ * codec_type: 0 = H.264, 1 = H.265, 2 = AV1.
+ * Returns NULL to mean "do not set the profile option".
+ */
+static const char *nvenc_resolve_profile(int codec_type, const char *in) {
+  if (codec_type == 0) { /* h264_nvenc: baseline/main/high/high444p */
+    if (!in || !*in)
+      return "high";
+    return in;
+  }
+  if (codec_type == 1) { /* hevc_nvenc: main/main10/rext */
+    if (in && (!strcmp(in, "main") || !strcmp(in, "main10") ||
+               !strcmp(in, "rext")))
+      return in;
+    return "main";
+  }
+  if (codec_type == 2) /* av1_nvenc: main */
+    return "main";
+  return NULL;
 }
 
 /* H.264/H.265 NAL类型定义 */
@@ -417,14 +446,17 @@ void *nvenc_encoder_create_internal(obs_data_t *settings,
   enc->codec_context->gop_size = enc->keyint;
   enc->codec_context->max_b_frames = enc->bframes;
 
-  /* For H.264 only: enable GLOBAL_HEADER so FFmpeg populates extradata at
-   * avcodec_open2() with an SPS/PPS sequence header. Without this, NVENC's
-   * extradata stays empty and OBS's RTMP/FLV muxer has no AVCDecoder-
-   * ConfigurationRecord to send, which causes ingest servers (e.g. Streamshark)
-   * to drop the stream within ~100ms with zero frames sent. We restore the
-   * inline SPS/PPS at each keyframe ourselves below, preserving MPEG-TS/SRT
-   * behaviour. H.265 keeps its v1.2.2 SLS-compat behaviour (no GLOBAL_HEADER). */
-  if (enc->codec_type == 0) {
+  /* Enable GLOBAL_HEADER for H.264 and H.265 so FFmpeg populates extradata at
+   * avcodec_open2() with a codec sequence header. Without it:
+   *   - H.264: OBS's RTMP/FLV muxer has no AVCDecoderConfigurationRecord
+   *     → ingest servers drop the stream within ~100ms.
+   *   - H.265: OBS's file/MPEG-TS muxer has no HEVCDecoderConfigurationRecord
+   *     → recording hangs at stop and SLS/SRT distribution fails (frames only
+   *     reach P2P listeners that happened to catch an in-band header).
+   * We re-inject SPS/PPS (and VPS for HEVC) inline at each keyframe below,
+   * preserving the v1.2.2 in-band-parameter-set behaviour for MPEG-TS/SRT
+   * receivers that join mid-stream. AV1 is left untouched. */
+  if (enc->codec_type == 0 || enc->codec_type == 1) {
     enc->codec_context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
   }
 
@@ -438,9 +470,14 @@ void *nvenc_encoder_create_internal(obs_data_t *settings,
   encoder_log(LOG_INFO, enc, "Using NVENC preset: %s (requested: %s)",
               nvenc_preset, (enc->preset && *enc->preset) ? enc->preset : "(default)");
 
-  /* Profile */
-  if (enc->profile && strlen(enc->profile) > 0) {
-    av_dict_set(&opts, "profile", enc->profile, 0);
+  /* Profile (coerce to codec-valid value — the UI exposes H.264 names for all
+   * codecs, but hevc_nvenc/av1_nvenc reject "high" with EINVAL). */
+  const char *nvenc_profile = nvenc_resolve_profile(enc->codec_type, enc->profile);
+  if (nvenc_profile) {
+    av_dict_set(&opts, "profile", nvenc_profile, 0);
+    encoder_log(LOG_INFO, enc, "Using NVENC profile: %s (requested: %s)",
+                nvenc_profile,
+                (enc->profile && *enc->profile) ? enc->profile : "(default)");
   }
 
   /* Rate control - CBR */
@@ -474,26 +511,28 @@ void *nvenc_encoder_create_internal(obs_data_t *settings,
     encoder_log(LOG_INFO, enc, "Extra data size: %zu bytes",
                 enc->extra_data_size);
 
-    /* For H.264 with GLOBAL_HEADER on, build a reusable Annex-B SPS/PPS
-     * payload so we can keep parameter sets inline at every keyframe (needed
-     * for SRT/MPEG-TS receivers that join mid-stream). */
-    if (enc->codec_type == 0) {
-      enc->inline_params = nvenc_h264_extradata_to_annexb(
+    /* For H.264 / H.265 with GLOBAL_HEADER on, build a reusable Annex-B
+     * parameter-set payload (SPS/PPS, plus VPS for HEVC) so we can keep
+     * parameter sets inline at every keyframe — required by MPEG-TS / SRT
+     * receivers (and SLS servers) that join mid-stream. */
+    if (enc->codec_type == 0 || enc->codec_type == 1) {
+      enc->inline_params = nvenc_extradata_to_annexb(
           enc->extra_data, enc->extra_data_size, &enc->inline_params_size);
       if (enc->inline_params && enc->inline_params_size > 0) {
         encoder_log(LOG_INFO, enc,
-                    "Inline SPS/PPS payload built: %zu bytes (Annex-B)",
+                    "Inline parameter set payload built: %zu bytes (Annex-B)",
                     enc->inline_params_size);
       } else {
         encoder_log(LOG_WARNING, enc,
-                    "Could not build inline SPS/PPS from extradata; SRT "
-                    "consumers may need to wait for next out-of-band header");
+                    "Could not build inline parameter sets from extradata; "
+                    "mid-stream MPEG-TS/SRT joiners may need to wait for the "
+                    "next out-of-band header");
       }
     }
-  } else if (enc->codec_type == 0) {
+  } else if (enc->codec_type == 0 || enc->codec_type == 1) {
     encoder_log(LOG_WARNING, enc,
-                "H.264 extradata is empty after open — RTMP/FLV will likely "
-                "fail (no AVC sequence header)");
+                "Extradata is empty after open — recording / RTMP will likely "
+                "fail (no codec sequence header in container)");
   }
 
   encoder_log(LOG_INFO, enc,

--- a/src/nvenc-encoder.h
+++ b/src/nvenc-encoder.h
@@ -33,9 +33,16 @@ typedef struct nvenc_encoder {
   int codec_type;      /* 0=H.264, 1=H.265, 2=AV1 */
   char codec_name[32]; /* FFmpeg encoder name */
 
-  /* Extra Data (SPS/PPS) */
+  /* Extra Data (SPS/PPS) returned to OBS via get_extra_data */
   uint8_t *extra_data;
   size_t extra_data_size;
+
+  /* Inline parameter sets in Annex-B form, prepended to each H.264 keyframe
+   * packet when AV_CODEC_FLAG_GLOBAL_HEADER is set (so FFmpeg no longer
+   * emits SPS/PPS inline). Keeps MPEG-TS/SRT consumers happy while letting
+   * RTMP/FLV consumers use the AVC sequence header from extra_data. */
+  uint8_t *inline_params;
+  size_t inline_params_size;
 
   /* NTP 同步 */
   struct ntp_client ntp_client;


### PR DESCRIPTION
## Summary

Fixes #5. Addresses #2 (NVENC & AMF encoder problems). Repairs the NVENC and
AMD AMF encoders across H.264 and H.265, which failed to open and/or distribute
on current drivers.

### 1. Legacy NVENC preset names rejected by modern drivers (the reported symptom)

NVIDIA deprecated the legacy NVENC preset names (`default/slow/medium/fast/hp/hq/...`)
with the R550 driver (Q1 2024), in favour of the SDK 10+ `p1`-`p7` family. The
unified encoder UI's default preset `"balanced"` is passed straight to FFmpeg's
`h264_nvenc`/`hevc_nvenc`, which rejects it with `EINVAL (-22)`. That is exactly
the `Failed to open NVENC encoder: Invalid argument (-22)` in the report. Adds a
translation helper (`fast`->`p2`, `balanced`->`p4`, `quality`->`p7`; valid
`p1`-`p7` pass through; unknown values fall back to `p4`). Applies to all codecs.

### 2. Codec-valid profile resolution (NVENC and AMF)

The UI exposes H.264 profile names (`baseline/main/high`) for every codec, but
`hevc_nvenc`/`hevc_amf` accept only `main` (and `main10/rext` for NVENC), and the
AV1 variants only `main`. The default `"high"` made `avcodec_open2` return EINVAL
for H.265 on both NVENC and AMF, so HEVC never opened. Coerces to a codec-valid
profile per encoder. (H.264 is unchanged on both.)

### 3. Missing codec sequence header breaks RTMP (H.264) and recording/SRT (H.265) on NVENC

Without `AV_CODEC_FLAG_GLOBAL_HEADER`, FFmpeg's NVENC wrappers leave
`codec_context->extradata` empty, so the muxer has no
`AVCDecoderConfigurationRecord` / `HEVCDecoderConfigurationRecord`:

- H.264 RTMP: ingest servers drop the connection within ~100 ms, zero frames sent.
- H.265 recording: muxer cannot finalise, so it hangs at stop.
- H.265 SLS/SRT: frames fail to distribute (only P2P listeners that catch an
  in-band header decode), matching the maintainer's note in #5.

Enables `GLOBAL_HEADER` for both NVENC codecs and re-injects SPS/PPS (plus VPS for
HEVC) inline at every keyframe from the now-populated extradata, preserving the
v1.2.2 in-band-parameter-set behaviour for MPEG-TS/SRT receivers that join
mid-stream. AMD AMF already emits inline parameter sets itself, so it needs only
the profile fix above, not this.

## Testing (current drivers)

- NVENC H.264: opens; RTMP holds and frames flow (was 0 frames/instant drop);
  `.ts` recording decodes end-to-end with SPS/PPS at every keyframe.
- NVENC H.265: opens; `.ts` recording stops cleanly and decodes end-to-end with
  VPS/SPS/PPS at every keyframe; SRT distributes.
- AMD AMF H.265 (Radeon iGPU): opens, records cleanly, SRT distributes. H.264 AMF
  unchanged and verified still working.

## Scope

NVENC and AMD AMF only. Intel QSV is unchanged by this PR. 

## References
- [NVENC Preset Migration Guide (SDK 13)](https://docs.nvidia.com/video-technologies/video-codec-sdk/13.0/nvenc-preset-migration-guide/)